### PR TITLE
fix: update git URLs to brickhouse-tech for npm OIDC provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "lint": "eslint src/",
     "prepublishOnly": "npm run build && npm test"
   },
-  "homepage": "https://github.com/nmccready/angular-simple-logger",
+  "homepage": "https://github.com/brickhouse-tech/angular-simple-logger",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nmccready/angular-simple-logger.git"
+    "url": "git+https://github.com/brickhouse-tech/angular-simple-logger.git"
   },
   "author": "Nicholas McCready",
   "license": "MIT",
@@ -62,5 +62,8 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "rollup": "^4.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/brickhouse-tech/angular-simple-logger/issues"
   }
 }


### PR DESCRIPTION
Updates repository, homepage, and bugs URLs in package.json to point to brickhouse-tech org so npm OIDC provenance works correctly during publish.