### PR TITLE
ci: skip CI for devcontainer and workflow-only changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,14 @@ name: Tests
 on:
   push:
     branches: [master, main]
+    paths-ignore:
+      - '.devcontainer/**'
+      - '.github/workflows/**'
   pull_request:
     branches: [master, main]
-
+    paths-ignore:
+      - '.devcontainer/**'
+      - '.github/workflows/**'
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add `paths-ignore` for `.devcontainer/**` and `.github/workflows/**` to push/pull_request triggers so CI doesn't run on non-functional changes.