### PR TITLE
fix: align release/publish workflows with cfn-include

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,25 +1,28 @@
-name: Publish to npm
-on:
-  release:
-    types: [published]
+name: publish
 
-permissions:
-  contents: read
-  id-token: write
+on:
+  push:
+    tags:
+      - "v*"
 
 jobs:
-  publish:
+  tests:
+    uses: ./.github/workflows/tests.yml
+  publish-npm:
+    needs: [tests]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org
-          cache: npm
-      - run: npm ci
-      - run: npm run build
-      - run: npm test
-      - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Publish to npm
+        run: | # npm 11.15.1 for OIDC support
+          npm install -g npm@11
+          npm ci
+          npm install
+          npm publish --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,47 +1,59 @@
-name: Release
-on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version bump (patch, minor, major)'
-        required: true
-        default: 'patch'
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
+# TODO: ENABLE / UNCOMMENT WHEN NPM_TOKEN IS SET in secrets REPO
+name: release
 
-permissions:
-  contents: write
+on:
+  push:
+    branches: ["master"]
+    tags-ignore: ['**']
 
 jobs:
-  release:
+  tests:
+    uses: ./.github/workflows/tests.yml
+  tag-release:
     runs-on: ubuntu-latest
+    needs: [tests]
     steps:
       - uses: actions/checkout@v4
         with:
+          # important, must be defined on checkout to kick publish
+          token: ${{ secrets.GH_TOKEN }}
+          # Full history needed for conventional-changelog to detect breaking changes
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
         with:
-          node-version: 22
-          cache: npm
-      - run: npm ci
-      - run: npm run build
-      - run: npm test
-      - name: Configure git
+          node-version: '20.x'
+
+      - name: tag release
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-      - name: Bump version
-        run: npm version ${{ inputs.version }} -m "chore: release v%s"
-      - name: Push
-        run: |
+          # ignore if commit message is chore(release): ...
+          if [[ $(git log -1 --pretty=%B) =~ ^chore\(release\):.* ]]; then
+            echo "Commit message starts with 'chore(release):', skipping release"
+            exit 0
+          fi
+
+          git config --local user.email "creadbot@github.com"
+          git config --local user.name "creadbot_github"
+
+          npm install
+
+          # Check for breaking changes in commits since last tag
+          # Look for feat!:, fix!:, or BREAKING CHANGE in commit messages
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -n "$LAST_TAG" ]; then
+            RANGE="$LAST_TAG..HEAD"
+          else
+            RANGE="HEAD"
+          fi
+
+          # Check all commits (not just first-parent) for breaking changes
+          if git log $RANGE --format="%B" | grep -qE "(^[a-z]+!:|BREAKING CHANGE:)"; then
+            echo "Breaking change detected, forcing major version bump"
+            npx commit-and-tag-version --release-as major
+          else
+            npx commit-and-tag-version
+          fi
+
           git push
           git push --tags
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          gh release create "v${VERSION}" --generate-notes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,27 +1,26 @@
-name: Tests
+name: tests
+
 on:
+  workflow_call:
   push:
-    branches: [master, main]
-    paths-ignore:
-      - '.devcontainer/**'
-      - '.github/workflows/**'
+    branches: ["master"]
   pull_request:
-    branches: [master, main]
-    paths-ignore:
-      - '.devcontainer/**'
-      - '.github/workflows/**'
+    branches: ["master"]
+
 jobs:
   test:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: ['20.x', '22.x', '24.x']
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
-      - run: npm ci
-      - run: npm run build
+          # cache: "npm" # needs lockfile if enabled
+
+      - run: npm install
+      - run: npm run lint
       - run: npm test


### PR DESCRIPTION
Replaces the old workflow_dispatch release with the cfn-include pattern:
- **release.yml**: push to master → tests → commit-and-tag-version → push tags (uses GH_TOKEN)
- **publish.yml**: tag v* → tests → npm publish with OIDC provenance (no NPM_TOKEN needed)