### PR TITLE
fix: rename workflow test job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,5 +6,5 @@ on:
   pull_request:
     branches: ["master"]
 jobs:
-  tests:
+  test:
     uses: brickhouse-tech/.github/.github/workflows/tests.yml@main


### PR DESCRIPTION
Rename the reusable workflow caller job from `tests` to `test` so the check name matches the org-wide convention.