### PR TITLE
fix(ci): point tests-complete needs at 'test' job so required check reports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,13 +11,13 @@ jobs:
 
   tests-complete:
     name: tests
-    needs: [tests]
+    needs: [test]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Check test results
         run: |
-          if [[ "${{ needs.tests.result }}" != "success" ]]; then
+          if [[ "${{ needs.test.result }}" != "success" ]]; then
             echo "Tests failed"
             exit 1
           fi


### PR DESCRIPTION
## Problem

The `tests` workflow has been failing at validation (0s, **no jobs created**) since the reusable job was renamed `tests` → `test`. The `tests-complete` gate still referenced the old name:

```yaml
needs: [tests]                 # no such job — job is `test`
... needs.tests.result ...
```

GitHub rejects the workflow (*"depends on unknown job tests"*), so **no `tests` status check is ever posted** → PRs requiring the `tests` check are stuck `BLOCKED` (e.g. Dependabot PRs that never pass).

## Fix

Point the gate at the real job id `test`. `name: tests` is unchanged, so the required check still reports as `tests` — no branch-protection change needed.

Found via org-wide audit of `tests.yml`. Same fix applied to debug-fabulous and angular-simple-logger (the two repos with this mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)